### PR TITLE
[All] Fix factionID type error on first install init

### DIFF
--- a/Core-Retail.lua
+++ b/Core-Retail.lua
@@ -606,15 +606,16 @@ function RepByZone:SwitchedZones()
     end
 
     -- Set the watched factionID
-    if faction then
+    if type(faction) == "number" then
         factionName, _, _, _, _, _, _, _, _, _, _, isWatched = GetFactionInfoByID(faction)
-    end
-    if factionName and not isWatched then
-        C_Reputation.SetWatchedFaction(faction)
-        if db.verbose then
-            self:Print(L["Now watching %s"]:format(factionName))
+
+        if factionName and not isWatched then
+            C_Reputation.SetWatchedFaction(faction)
+            if db.verbose then
+                self:Print(L["Now watching %s"]:format(factionName))
+            end
+        elseif db.watchedRepID == "0-none" then
+            C_Reputation.SetWatchedFaction(0) -- Clear watched faction
         end
-    elseif db.watchedRepID == "0-none" then
-        C_Reputation.SetWatchedFaction(0) -- Clear watched faction
     end
 end

--- a/Core-Vanilla.lua
+++ b/Core-Vanilla.lua
@@ -324,15 +324,16 @@ function RepByZone:SwitchedZones()
     end
 
     -- Set the watched factionID
-    if faction then
+    if type(faction) == "number" then
         factionName, _, _, _, _, _, _, _, _, _, _, isWatched = GetFactionInfoByID(faction)
-    end
-    if factionName and not isWatched then
-        C_Reputation.SetWatchedFaction(faction)
-        if db.verbose then
-            self:Print(L["Now watching %s"]:format(factionName))
+
+        if factionName and not isWatched then
+            C_Reputation.SetWatchedFaction(faction)
+            if db.verbose then
+                self:Print(L["Now watching %s"]:format(factionName))
+            end
+        elseif db.watchedRepID == "0-none" then
+            C_Reputation.SetWatchedFaction(0) -- Clear watched faction
         end
-    elseif db.watchedRepID == "0-none" then
-        C_Reputation.SetWatchedFaction(0) -- Clear watched faction
     end
 end

--- a/Core-Wrath.lua
+++ b/Core-Wrath.lua
@@ -434,15 +434,16 @@ function RepByZone:SwitchedZones()
     end
 
     -- Set the watched factionID
-    if faction then
+    if type(faction) == "number" then
         factionName, _, _, _, _, _, _, _, _, _, _, isWatched = GetFactionInfoByID(faction)
-    end
-    if factionName and not isWatched then
-        C_Reputation.SetWatchedFaction(faction)
-        if db.verbose then
-            self:Print(L["Now watching %s"]:format(factionName))
+
+        if factionName and not isWatched then
+            C_Reputation.SetWatchedFaction(faction)
+            if db.verbose then
+                self:Print(L["Now watching %s"]:format(factionName))
+            end
+        elseif db.watchedRepID == "0-none" then
+            C_Reputation.SetWatchedFaction(0) -- Clear watched faction
         end
-    elseif db.watchedRepID == "0-none" then
-        C_Reputation.SetWatchedFaction(0) -- Clear watched faction
     end
 end


### PR DESCRIPTION
There was a type error in `GetFactionInfoByID` when RepByZone was first installed, so we fixed that.